### PR TITLE
Fix two Sphinx warnings when building docs

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,7 @@ templates_path = ["_templates"]
 # List of patterns, relative to source directory, that match files and
 # directories to ignore when looking for source files.
 # This pattern also affects html_static_path and html_extra_path.
-exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
+exclude_patterns = ["_build", "Thumbs.db", ".DS_Store", "requirements.txt"]
 
 
 # -- Options for HTML output -------------------------------------------------
@@ -51,7 +51,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ["_static"]
+# html_static_path = ["_static"]
 
 # The suffix of source filenames.
 source_suffix = ".txt"


### PR DESCRIPTION
For posterity, the two warnings fixed by this PR:

* crispy-tailwind/docs/requirements.txt: WARNING: document isn't included in any toctree
* WARNING: html_static_path entry '_static' does not exist