### PR TITLE
Replace link placeholder in documentation index

### DIFF
--- a/docs/index.txt
+++ b/docs/index.txt
@@ -6,7 +6,10 @@
 Welcome to crispy-tailwind's documentation!
 ===========================================
 
-This is a Tailwind template pack for django-crispy-forms (insert link)
+This is a Tailwind template pack for django-crispy-forms_.
+
+.. _django-crispy-forms: https://django-crispy-forms.readthedocs.io/en/latest/index.html
+
 
 .. toctree::
    :maxdepth: 2


### PR DESCRIPTION
I think this link placeholder was meant to be eventually replaced with an actual link, so I took the liberty of doing that in this pull request.