### PR TITLE
Ensure code style is properly checked by Flake8

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -29,7 +29,4 @@ jobs:
         isort . --check --dif
     - name: run flake8
       run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings.
-        flake8 . --exit-zero
+        flake8 .

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,7 +20,7 @@ statistics = True
 max-complexity = 10
 count = True
 select = C,E,F,W,B
-ignore = E203, W503
+ignore = E203, W503, E501
 
 [coverage:run]
 plugins = django_coverage_plugin

--- a/tests/test_filter.py
+++ b/tests/test_filter.py
@@ -35,19 +35,19 @@ class CrispyFilterTests(SimpleTestCase):
             <small id="hint_id_email" class="text-gray-600">Insert your email</small> </div>
 
             <div id="div_id_password1" class="mb-3">
-            <label for="id_password1" class="block text-gray-700 text-sm font-bold mb-2">password<span 
+            <label for="id_password1" class="block text-gray-700 text-sm font-bold mb-2">password<span
             class="asteriskField">*</span>
             </label>
-            <input type="password" name="password1" maxlength="30" 
+            <input type="password" name="password1" maxlength="30"
             class="passwordinput w-full rounded-lg """
             """border appearance-none py-2 border-gray-300 bg-white text-gray-700 focus:outline-none px-4 block """
-            """leading-normal" required id="id_password1"> 
+            """leading-normal" required id="id_password1">
             </div>
 
             <div id="div_id_password2" class="mb-3">
             <label for="id_password2" class="block text-gray-700 text-sm font-bold mb-2">
             re-enter password<span class="asteriskField">*</span> </label>
-            <input type="password" name="password2" maxlength="30" 
+            <input type="password" name="password2" maxlength="30"
             class="passwordinput w-full rounded-lg """
             """border appearance-none py-2 border-gray-300 bg-white text-gray-700 focus:outline-none px-4 block """
             """leading-normal"
@@ -72,7 +72,7 @@ class CrispyFilterTests(SimpleTestCase):
             <div id="div_id_datetime_field" class="mb-3">
             <label for="id_datetime_field_0" class="block text-gray-700 text-sm font-bold mb-2">
             date time<span class="asteriskField">*</span> </label>
-            <input type="text" name="datetime_field_0" 
+            <input type="text" name="datetime_field_0"
             class="dateinput rounded-lg focus:outline border appearance-none py-2 mr-2 border-gray-300 bg-white """
             """text-gray-700 focus:outline-none px-4 leading-normal" required id="id_datetime_field_0">
             <input type="text" name="datetime_field_1" class="timeinput rounded-lg focus:outline border """
@@ -125,10 +125,10 @@ class CrispyFilterTests(SimpleTestCase):
         formset = formset_factory(ShortCharFieldForm, extra=2)
         c = Context({"form": formset})
         html = template.render(c)
-        expected_html = """     
+        expected_html = """
             <input type="hidden" name="form-TOTAL_FORMS" value="2" id="id_form-TOTAL_FORMS" /> <input type="hidden" name="form-INITIAL_FORMS" value="0" id="id_form-INITIAL_FORMS" />
             <input type="hidden" name="form-MIN_NUM_FORMS" value="0" id="id_form-MIN_NUM_FORMS" /> <input type="hidden" name="form-MAX_NUM_FORMS" value="1000" id="id_form-MAX_NUM_FORMS" />
-            
+
             <div class="multiField">
                 <div id="div_id_form-0-name" class="mb-3">
                     <label for="id_form-0-name" class="block text-gray-700 text-sm font-bold mb-2"> Name<span class="asteriskField">*</span> </label>
@@ -141,7 +141,7 @@ class CrispyFilterTests(SimpleTestCase):
                     />
                 </div>
             </div>
-            
+
             <div class="multiField">
                 <div id="div_id_form-1-name" class="mb-3">
                     <label for="id_form-1-name" class="block text-gray-700 text-sm font-bold mb-2"> Name<span class="asteriskField">*</span> </label>

--- a/tests/test_helper.py
+++ b/tests/test_helper.py
@@ -1,5 +1,5 @@
 from django.forms.models import formset_factory
-from django.template import Context, Template
+from django.template import Template
 from django.test import SimpleTestCase
 
 from crispy_forms.bootstrap import InlineCheckboxes, InlineRadios

--- a/tests/test_table_inline_formset.py
+++ b/tests/test_table_inline_formset.py
@@ -199,7 +199,7 @@ class CrispyHelperTests(SimpleTestCase):
                 <div class=""><input type="submit" name="submit" value="submit" class="bg-green-500 hover:bg-green-700 text-white font-bold py-2 px-4 rounded" id="submit-id-submit" /></div>
             </div>
         </div>
-    
+
         """
         self.assertHTMLEqual(html, expected_html)
 


### PR DESCRIPTION
I made these changes before noticing #34 and realizing the obvious overlap. The main difference between this PR and the changes in #34 is that this PR does not attempt to re-indent the HTML tags in `tests/test_filter.py`, and the two spurious spaces inside the `checkboxinput` class are for the moment left as-is.

I know within the other PR @smithdc1 expressed a desire to split the above test into smaller pieces, but for the moment I suggest applying these changes first and then addressing the test-splitting endeavor in a subsequent task. That way at least any near-term commits to the project will be properly checked for code style, with any violations caught via CI.

Just my two cents, of course. I hope this is helpful. 💫