### PR TITLE
Bug fix - select layout double dropdown icon

### DIFF
--- a/crispy_tailwind/templates/tailwind/layout/select.html
+++ b/crispy_tailwind/templates/tailwind/layout/select.html
@@ -7,8 +7,5 @@
         {% include "tailwind/layout/select_option.html" with value=value label=label %}
     {% endfor %}
 </select>
-<div class="pointer-events-none absolute inset-y-0 right-0 flex items-center px-2 text-gray-700">
-    <svg class="fill-current h-4 w-4" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path d="M9.293 12.95l.707.707L15.657 8l-1.414-1.414L10 10.828 5.757 6.586 4.343 8z"/></svg>
-  </div>
 </div>
 </div>


### PR DESCRIPTION
Fix for the problem mentioned on the [first comment](https://github.com/django-crispy-forms/crispy-tailwind/issues/110#issuecomment-974617762) on issue [#110](https://github.com/django-crispy-forms/crispy-tailwind/issues/110).