### PR TITLE
Automate GitHub releases & PyPI package publication

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -6,6 +6,9 @@ on:
     - main
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   tests:
     name: Python ${{ matrix.python-version }}
@@ -51,3 +54,43 @@ jobs:
         flags: unittests
         name: codecov-umbrella
         fail_ci_if_error: false
+
+
+  deploy:
+    name: Deploy
+    needs: [tests]
+    runs-on: ubuntu-latest
+    if: github.ref=='refs/heads/main' && github.event_name!='pull_request'
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.10"
+
+      - name: Check release
+        id: check_release
+        run: |
+          python -m pip install autopub
+          python -m pip install https://github.com/autopub/github-release/archive/pyproject.zip
+          autopub check
+
+      - name: Publish
+        if: ${{ steps.check_release.outputs.autopub_release=='true' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          autopub prepare
+          autopub commit
+          autopub build
+          autopub githubrelease
+
+      - name: Upload package to PyPI
+        if: ${{ steps.check_release.outputs.autopub_release=='true' }}
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
-# CHANGELOG for crispy-tailwind
+CHANGELOG
+=========
 
-## Next Release (tbc)
+1.0.0 - 2024-01-09
+------------------
 
-## 1.0 (2024-01-09)
 * Added support for Django 5.0 (#142)
 * Added support for Python 3.11 and 3.12 (#142)
 * Added support for Python 3.10 (#116)
@@ -15,7 +16,9 @@
 * Added docs about Tailwind CLI template discovery management command (#144)
 * Fixed bug with select template and disabled property (#118)
 
-## 0.5 (2021-04-21)
+0.5.0 - 2021-04-21
+------------------
+
 * Added support for custom widgets (#92)
 * Confirmed support for Django 3.2 (#91)
 * Dropped support for Django 3.1 (#91)
@@ -23,14 +26,18 @@
 See [Release Notes](https://github.com/django-crispy-forms/crispy-tailwind/milestone/5?closed=1)
 for full change log.
 
-## 0.4 (2021-03-22)
+0.4.0 - 2021-03-22
+------------------
+
 * Fixed compatibility with django-crispy-forms 1.11.2 (#86)
 * Fixed field names when using formsets (#84)
 
 See [Release Notes](https://github.com/django-crispy-forms/crispy-tailwind/milestone/4?closed=1)
 for full change log.
 
-## 0.3 (2021-02-14)
+0.3.0 - 2021-02-14
+------------------
+
 * Fixed non form errors (#77)
 * Various documentation improvements
 * Python 3.9 (#60) and Django 3.1 (#56) support
@@ -38,7 +45,8 @@ for full change log.
 See [Release Notes](https://github.com/django-crispy-forms/crispy-tailwind/milestone/3?closed=1)
 for full change log.
 
-## 0.2 (2020-07-11)
+0.2.0 - 2020-07-11
+------------------
 
 * Support for Formsets
 * Prepended and Appended inputs
@@ -50,7 +58,8 @@ for full change log.
 See [Release Notes](https://github.com/django-crispy-forms/crispy-tailwind/milestone/2?closed=1)
 for full change log.
 
-## 0.1 (2020-06-09)
+0.1.0 - 2020-06-09
+------------------
 
 * First Release, please do come and test!
 * Opinionated forms can be rendered with crispy filter

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,6 +48,12 @@ version = {attr = "crispy_tailwind.__version__"}
 "Issues" = "https://github.com/django-crispy-forms/crispy-tailwind/issues"
 "Changelog" = "https://github.com/django-crispy-forms/crispy-tailwind/releases"
 
+[tool.autopub]
+project-name = "Crispy-Tailwind"
+git-username = "botpub"
+git-email = "52496925+botpub@users.noreply.github.com"
+append-github-contributor = true
+
 [tool.black]
 line-length = 119
 target-version = ['py38']


### PR DESCRIPTION
This pull request adds a job to the existing GitHub Actions `CI.yml` workflow that uses [AutoPub](https://justinmayer.com/projects/autopub/) to automatically release and publish new packages to PyPI when a release file is merged or pushed into the `main` branch.

As part of this endeavor, I also took this opportunity to replace the `twine upload` step with PyPI's new [Trusted Publisher](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) system. In addition to the changes in this pull request, the only remaining step needed to utilize the [Trusted Publisher](https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/) system is for someone with more permissions than I currently have to do one of the following two things:

1. Send me an invitation to join the `crispy-tailwind` PyPI project with Owner role (my PyPI username is `jmayer`), after which I would be happy to set everything up.
2. Since @smithdc1 is currently the only person with access to the PyPI project, David can go to https://pypi.org/manage/project/crispy-tailwind/settings/publishing/, fill out the form with the values below, and submit the form.

**Owner**: `django-crispy-forms`
**Repository name**: `crispy-tailwind`
**Workflow name**: `CI.yml`
**Environment name**: (optional — can leave this field empty)

Rather than add PDM/Hatch as discussed in #149, I elected to defer that endeavor and instead retain Setuptools as the build back-end for now in an effort to keep the scope as narrow as possible.

Closes #149