### PR TITLE
Fix: Subwidgets are now rendered using their own type

### DIFF
--- a/crispy_tailwind/tailwind.py
+++ b/crispy_tailwind/tailwind.py
@@ -4,6 +4,8 @@
 
 import re
 
+from django.forms import Field, Widget, boundfield
+
 
 class CSSContainer:
     def __init__(self, css_styles):
@@ -67,6 +69,15 @@ class CSSContainer:
             setattr(self, field, new_classes)
         return self
 
-    def get_input_class(self, field):
-        widget_name = re.sub(r"widget$|input$", "", field.field.widget.__class__.__name__.lower())
+    def get_input_class(self, obj):
+        # Following check is used to keep backward compatibility with older versions
+        if isinstance(obj, boundfield.BoundField):
+            widget = obj.field.widget
+        elif isinstance(obj, Field):
+            widget = obj.widget
+        elif isinstance(obj, Widget):
+            widget = obj
+        else:
+            raise ValueError("Object must be a BoundField, Field or Widget")
+        widget_name = re.sub(r"widget$|input$", "", widget.__class__.__name__.lower())
         return getattr(self, widget_name, "")

--- a/crispy_tailwind/templatetags/tailwind_field.py
+++ b/crispy_tailwind/templatetags/tailwind_field.py
@@ -4,11 +4,11 @@
 
 import re
 
+from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 from django import forms, template
 from django.conf import settings
 from django.template import Context, loader
 
-from crispy_forms.utils import TEMPLATE_PACK, get_template_pack
 from crispy_tailwind.tailwind import CSSContainer
 
 register = template.Library()
@@ -161,7 +161,7 @@ class CrispyTailwindFieldNode(template.Node):
             if template_pack == "tailwind" and '"class"' not in attr.keys():
                 css_container = context.get("css_container", self.default_container)
                 if css_container:
-                    css = " " + css_container.get_input_class(field)
+                    css = " " + css_container.get_input_class(widget)
                     css_class += css
                 if field.errors:
                     error_border_class = css_container.error_border


### PR DESCRIPTION
Fix for https://github.com/django-crispy-forms/crispy-tailwind/issues/171