### PR TITLE
Remove x character at end of help text

### DIFF
--- a/crispy_tailwind/templates/tailwind/layout/help_text.html
+++ b/crispy_tailwind/templates/tailwind/layout/help_text.html
@@ -1,6 +1,6 @@
 {% if field.help_text %}
     {% if help_text_inline %}
-        <p {% if field.id_for_label %}id="{{ field.id_for_label }}_helptext" {% endif %}class="text-gray-600">{{ field.help_text|safe }}</p>x
+        <p {% if field.id_for_label %}id="{{ field.id_for_label }}_helptext" {% endif %}class="text-gray-600">{{ field.help_text|safe }}</p>
     {% else %}
         <small {% if field.id_for_label %}id="{{ field.id_for_label }}_helptext" {% endif %}class="text-gray-600">{{ field.help_text|safe }}</small>
     {% endif %}


### PR DESCRIPTION
Errant 'x' char showing at end of text when help_text_inline is True